### PR TITLE
Support aasm 4.1 and above

### DIFF
--- a/graphviz_aasm.gemspec
+++ b/graphviz_aasm.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 2.14"
 
-  spec.add_dependency "aasm", "> 3.2"
+  spec.add_dependency "aasm", "~> 4.1"
   spec.add_dependency "activesupport", "~> 4.1"
   spec.add_dependency "railties", "~> 4.1"
   spec.add_dependency "ruby-graphviz", "~> 1.0"

--- a/graphviz_aasm.gemspec
+++ b/graphviz_aasm.gemspec
@@ -1,6 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+$:.push File.expand_path('../lib', __FILE__)
 require 'graphviz_aasm/version'
 
 Gem::Specification.new do |spec|

--- a/graphviz_aasm.gemspec
+++ b/graphviz_aasm.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 2.14"
 
-  spec.add_dependency "aasm", "~> 3.2"
+  spec.add_dependency "aasm", "> 3.2"
   spec.add_dependency "activesupport", "~> 4.1"
   spec.add_dependency "railties", "~> 4.1"
   spec.add_dependency "ruby-graphviz", "~> 1.0"

--- a/graphviz_aasm.gemspec
+++ b/graphviz_aasm.gemspec
@@ -17,12 +17,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 10.3"
-  spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 
   spec.add_dependency "aasm", "~> 4.1"
-  spec.add_dependency "activesupport", "~> 4.1"
-  spec.add_dependency "railties", "~> 4.1"
-  spec.add_dependency "ruby-graphviz", "~> 1.0"
+  spec.add_dependency "activesupport"
+  spec.add_dependency "railties"
+  spec.add_dependency "ruby-graphviz"
 end

--- a/lib/graphviz_aasm.rb
+++ b/lib/graphviz_aasm.rb
@@ -19,7 +19,7 @@ module GraphvizAasm
           state.draw(graph)
         end
 
-        klass.aasm.events.each_value do |event|
+        klass.aasm.events.each do |event|
           event.draw(graph)
         end
         graph.output
@@ -27,18 +27,18 @@ module GraphvizAasm
     end
   end
 
-  AASM::State.class_eval do
+  AASM::Core::State.class_eval do
     def draw(graph)
       node = graph.add_nodes(self.human_name, shape: final? ? "doublecircle" : "ellipse")
       graph.add_edge(graph.add_nodes("starting_state", shape: "point"), node) if initial?
     end
 
     def initial?
-      @clazz.aasm.initial_state == self.name
+      @klass.aasm.initial_state == self.name
     end
 
     def final?
-      !@clazz.aasm.events.any? do |_, event|
+      !@klass.aasm.events.any? do |event|
         event.transitions.any? do |transition|
           transition.from == self.name
         end
@@ -46,7 +46,7 @@ module GraphvizAasm
     end
   end
 
-  AASM::Event.class_eval do
+  AASM::Core::Event.class_eval do
     def draw(graph)
       transitions.each do |transition|
         graph.add_edge(transition.from.to_s.capitalize, transition.to.to_s.capitalize)

--- a/spec/lib/graphviz_aasm_spec.rb
+++ b/spec/lib/graphviz_aasm_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
 
 describe GraphvizAasm do
-  pending
+  skip
 end


### PR DESCRIPTION
- Support the latest AASM releases (~> 4.1) and its changes.
- Relaxed gemspec's other dependencies. 
- Support rspec 3.