### PR TITLE
Standardize state names

### DIFF
--- a/lib/graphviz_aasm.rb
+++ b/lib/graphviz_aasm.rb
@@ -29,7 +29,7 @@ module GraphvizAasm
 
   AASM::Core::State.class_eval do
     def draw(graph)
-      node = graph.add_nodes(self.human_name, shape: final? ? "doublecircle" : "ellipse")
+      node = graph.add_nodes(self.to_s, shape: final? ? "doublecircle" : "ellipse")
       graph.add_edge(graph.add_nodes("starting_state", shape: "point"), node) if initial?
     end
 
@@ -49,7 +49,7 @@ module GraphvizAasm
   AASM::Core::Event.class_eval do
     def draw(graph)
       transitions.each do |transition|
-        graph.add_edge(transition.from.to_s.capitalize, transition.to.to_s.capitalize)
+        graph.add_edge(transition.from.to_s, transition.to.to_s)
       end
     end
   end


### PR DESCRIPTION
Hi @romatr, I noticed an issue occurring when states have names containing underscores, so I figured this gem could keep the original state names.