### PR TITLE
Support rails 5

### DIFF
--- a/lib/aasm/graph.rb
+++ b/lib/aasm/graph.rb
@@ -5,7 +5,7 @@ module AASM
     def initialize(class_name, options = {})
       options = {path: '.'}.merge(options)
 
-      @file_path = File.join(options[:path], "#{class_name.parameterize('_')}_aasm.png")
+      @file_path = File.join(options[:path], "#{class_name.parameterize(separator: '_')}_aasm.png")
       super(:G)
     end
 


### PR DESCRIPTION
There is an adoption needed to use this gem with rails 5. This PR fixes the deprecated API call, but does not do any of the versioning required to release a rails 5 compatible version of the gem.

CC @bradsokol